### PR TITLE
Fix elixir-ls crashes

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get install -y wget gnupg2 inotify-tools locales && \
   wget https://packages.erlang-solutions.com/erlang-solutions_2.0_all.deb && \ 
   dpkg -i erlang-solutions_2.0_all.deb && \
   apt-get update -y && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y erlang-dev erlang-parsetools elixir
+  DEBIAN_FRONTEND=noninteractive apt-get install -y erlang-dev erlang-parsetools elixir erlang-dialyzer erlang-edoc
 
 SHELL ["/bin/bash", "-c"]
 RUN git config --global advice.detachedHead false


### PR DESCRIPTION
How I discovered this: I was getting an error popping up for ElixirLS. Going to View -> Output showed me this:

`https://github.com/elixir-lsp/elixir-ls/blob/master/guides/incomplete-installation.md#edoc-missing`

and that's how I fixed it.