### PR TITLE
Adds methods to save events

### DIFF
--- a/metricator/lib/dev/support/date_generator.ex
+++ b/metricator/lib/dev/support/date_generator.ex
@@ -1,14 +1,14 @@
 defmodule Metricator.DateGenerator do
 
   def generate_random_timestamps_for_days_ago(days, from_date \\ DateTime.utc_now(), events_per_day_upper_bound \\ 30) do
-    Enum.map(0..(days - 1), fn index ->
+    Enum.flat_map(0..(days - 1), fn index ->
       older_date = Timex.shift(from_date, days: -index)
 
       number_of_timestamps = :rand.uniform(events_per_day_upper_bound)
       Enum.map(0..number_of_timestamps, fn _index ->
-        DateTime.new(
+        DateTime.new!(
           older_date |> DateTime.to_date(),
-          Time.new!(:rand.uniform(23), :rand.uniform(59), :rand.uniform(59))
+          Time.new!(:rand.uniform(23), :rand.uniform(59), :rand.uniform(59), :rand.uniform(1000000))
         )
       end)
     end)

--- a/metricator/lib/dev/support/event_generator.ex
+++ b/metricator/lib/dev/support/event_generator.ex
@@ -7,14 +7,21 @@ defmodule Metricator.EventGenerator do
     }
   end
 
+  def generate_launch_event(date) do
+    event(%{
+      "activity" => "user_launch",
+      "user_id" => Ecto.UUID.generate(),
+    }, date)
+  end
 
   def generate_launch_events_for_past_month() do
     dates = Metricator.DateGenerator.generate_random_timestamps_for_days_ago(30)
-    Enum.map(dates, fn date ->
-      event(%{
-        "activity" => "user_launch",
-        "user_id" => Ecto.UUID.generate(),
-      }, date)
-    end)
+    Enum.map(dates, &generate_launch_event/1)
+  end
+
+  def save_events(events) do
+    for event <- events do
+      Metricator.Repo.insert!(event)
+    end
   end
 end


### PR DESCRIPTION
To test this out, `iex -S mix` and 

```
iex(1)> import Metricator.EventGenerator
iex(2)> generate_launch_events_for_past_month() |> save_events()
```